### PR TITLE
tweaking up a number of things

### DIFF
--- a/src/assets/crisistextline/sass/partials/03-components/_conversation.scss
+++ b/src/assets/crisistextline/sass/partials/03-components/_conversation.scss
@@ -103,11 +103,10 @@
             width: 200px;
             padding-bottom: 0;
 
-            .conversation-content, .conversation-title .timestamp {
-                display: none;
-            }
-
-            .conversation-content, .conversation-title .pending-transfer {
+            .conversation-content,
+            .conversation-title .timestamp,
+            .conversation-title .pending-transfer,
+            .conversation-blocker {
                 display: none;
             }
         }

--- a/src/assets/crisistextline/sass/partials/03-components/_nav.scss
+++ b/src/assets/crisistextline/sass/partials/03-components/_nav.scss
@@ -1,4 +1,5 @@
 nav, .nav {
+    margin-left: .5em;
     li.active>a {
         background-color: rgba(255,255,255,.4);
     }
@@ -58,10 +59,6 @@ nav, .nav {
             }
         }
     }
-}
-
-#main-wrapper .pip {
-    left: 1.5em;
 }
 
 .section-admin nav a, .section-admin .nav a {

--- a/src/assets/crisistextline/sass/partials/03-components/_sidebar.scss
+++ b/src/assets/crisistextline/sass/partials/03-components/_sidebar.scss
@@ -1,5 +1,5 @@
 @charset "UTF-8";
-$user-status-height: 8em;
+$user-status-height: 8.5em;
 
 #sidebar {
     float: left;

--- a/src/assets/crisistextline/sass/partials/04-structures/_profile.scss
+++ b/src/assets/crisistextline/sass/partials/04-structures/_profile.scss
@@ -48,7 +48,7 @@
     }
     .icons {
         display: inline-block;
-        margin: .75em 0 0 .75em;
+        margin: .5em 0 0 .5em;
         div {
             display: inline-block;
             vertical-align: middle;
@@ -395,11 +395,10 @@ $icon-width: 2em;
 }
 
 .namebar-left {
-    .conversation-status, .actor-carrier {
+    #profile-ids {
         clear: both;
         float: left;
-        margin-bottom: .5em;
-        margin-top: -.25em;
+        margin-bottom: 1em;
         margin-left: 2.5em;
         cursor: default;
     }


### PR DESCRIPTION
- adds a small padding back to the nav bar (so it doesn't butt directly up against queue health)
- adds the added padding on `#sidebar .user-stats` for calculating the height of the chat stuff
- de-dumbifies action board pips
- hides mgt plan reminder if convo is minimized
- realigns the icons div in actor/convo profile
- adds the FB icon to actor profiles (in addition to convo profiles)
