### PR TITLE
Showing a star for CCs with one year in the platform

### DIFF
--- a/src/assets/crisistextline/sass/partials/03-components/_sidebar.scss
+++ b/src/assets/crisistextline/sass/partials/03-components/_sidebar.scss
@@ -318,6 +318,18 @@ ul.cc {
             left: 0;
         }        
     }
+
+    li.chatUser.one-year {
+        .user-name:before {
+            content: "\2605";
+            color: $color-green;
+            font-size: 1.65em;
+            line-height: 0.6em;
+            font-weight: normal;
+            position: absolute;
+            left: 0;
+        }
+    }
 }
 
 .sidebar-tabs {


### PR DESCRIPTION
I hijacked the star for CCs but I've received the payment so here you have it back:

![screen shot 2016-09-30 at 11 35 41 am](https://cloud.githubusercontent.com/assets/10585657/18987595/944df066-8702-11e6-8e4f-4408b9f5d405.png)
