### PR TITLE
Don't let general role=main>div override conversations div positioning

### DIFF
--- a/src/assets/crisistextline/sass/partials/03-components/_main.scss
+++ b/src/assets/crisistextline/sass/partials/03-components/_main.scss
@@ -109,6 +109,9 @@ div[role="main"] {
         padding: 0 $padding-main-div $padding-main-div;
         position: relative;
     }
+    &>div.conversations {
+        position: absolute;
+    }
     ul {
         padding: 0;
         list-style-type: square;


### PR DESCRIPTION
The Conversations div should be absolutely positioned, but it's getting overridden by the `div[role="main"]>div` rule in Safari, which for some reason likes to occasionally apply the cascading stylesheets in weird orders.