### PR TITLE
No browser sniffing, just swap margin-top to padding-top

### DIFF
--- a/src/assets/crisistextline/sass/partials/03-components/_main.scss
+++ b/src/assets/crisistextline/sass/partials/03-components/_main.scss
@@ -96,13 +96,9 @@ body > div.flash {
 div[role="main"] {
     @include calc(width, 100% - #{$width-sidebar-left});
     float: right;
-    margin-top: 1.2*$header-height;
-    padding-top: 0;
+    padding-top: 1.2*$header-height;
+    margin-top: 0;
     background-color: white;
-    @supports (overflow:-webkit-marquee) and (justify-content:inherit) {
-        padding-top: 1.2*$header-height;
-        margin-top: 0;
-    }
     &>div {
         height: 100%;
         overflow-y: scroll;


### PR DESCRIPTION
The @supports code doesn't seem to work in Safari 10.0.3, not sure whats up with that. But browser-sniffing is bad form anyway, so lets just switch to padding-top for everyone.