### PR TITLE
remove zindex for tabs which seems unnecessary

### DIFF
--- a/src/assets/crisistextline/sass/partials/01-base/_zindices.scss
+++ b/src/assets/crisistextline/sass/partials/01-base/_zindices.scss
@@ -37,10 +37,6 @@ div[role="main"] .right-sidebar {
     z-index: 10;
 }
 
-#tabs {
-    z-index: 5;
-}
-
 #wrapper-survey form div.survey-buttons {
     z-index: 3;
 }


### PR DESCRIPTION
Fixes this: 
![image](https://user-images.githubusercontent.com/4480480/36166195-bb7adc7e-10bf-11e8-87f7-0cc56c2a8ad1.png)
