### PR TITLE
Add enabled to hover selector for buttonPrimary

### DIFF
--- a/src/assets/crisistextline/sass/partials/02-elements/_buttons.scss
+++ b/src/assets/crisistextline/sass/partials/02-elements/_buttons.scss
@@ -133,7 +133,7 @@ button.active,
     color: #fff;
   }
   
-  .buttonPrimary:hover, .buttonPrimary:focus, .buttonPrimary:active {
+  .buttonPrimary:enabled:hover, .buttonPrimary:enabled:focus, .buttonPrimary:active {
     background-color: #afc3d1 !important;
     border: 1px solid #afc3d1;
     color: #fff;


### PR DESCRIPTION
Makes sure the hover style actually gets applied. Without this change, the color gets overridden by another style when hovering. 