### PR TITLE
Facebook icon should have transparent background

### DIFF
--- a/src/assets/crisistextline/sass/partials/04-structures/_profile.scss
+++ b/src/assets/crisistextline/sass/partials/04-structures/_profile.scss
@@ -526,6 +526,7 @@ $icon-width: 2em;
     &.admin-facebook-form {
         background-image: image-url('sprites.png');
         background-position: -6px -486px;
+        background-color: transparent;
         &:hover {
             background-position: -46px -486px;
         }


### PR DESCRIPTION
After:
<img width="365" alt="image" src="https://user-images.githubusercontent.com/4480480/42387916-72306e98-8109-11e8-9f09-8658215f207a.png">

Before: 
<img width="371" alt="image" src="https://user-images.githubusercontent.com/4480480/42387931-8305ccd6-8109-11e8-8cb8-4315e6dad741.png">
