### PR TITLE
Added vertical-options class for admin forms

### DIFF
--- a/src/assets/crisistextline/sass/partials/02-elements/_forms.scss
+++ b/src/assets/crisistextline/sass/partials/02-elements/_forms.scss
@@ -103,6 +103,27 @@ textarea {
     }
 }
 
+.vertical-options {
+    label {
+        vertical-align: top;
+    }
+    label + div {
+        display: inline-block;
+        overflow: hidden;
+
+        input[type="radio"],
+        input[type="checkbox"],
+        input[type="radio"] + label,
+        input[type="checkbox"] + label {
+            float: left;
+        }
+        input[type="radio"],
+        input[type="checkbox"]{
+            clear: both;
+        }
+    }
+}
+
 input[type="text"]::-webkit-input-placeholder,
 input[type="search"]::-webkit-input-placeholder,
 input[type="password"]::-webkit-input-placeholder,


### PR DESCRIPTION
Adds a css class to style input checkboxes and radios to have a vertical orientation:

Preview:
![Screenshot+2021-01-25+10 31 14](https://user-images.githubusercontent.com/1541157/105749694-9d5dc280-5ef8-11eb-8617-07b0298402fd.png)
